### PR TITLE
Updated Terraform Provider for CDP namespace to cloudera/cdp

### DIFF
--- a/modules/terraform-cdp-aws-pre-reqs/provider.tf
+++ b/modules/terraform-cdp-aws-pre-reqs/provider.tf
@@ -23,7 +23,7 @@ terraform {
       version = "3.2.1"
     }
     cdp = {
-      source  = "cloudera-labs/cdp"
+      source  = "cloudera/cdp"
       version = "0.1.3-pre"
     }
     random = {

--- a/modules/terraform-cdp-deploy/provider.tf
+++ b/modules/terraform-cdp-deploy/provider.tf
@@ -15,7 +15,7 @@
 terraform {
   required_providers {
     cdp = {
-      source  = "cloudera-labs/cdp"
+      source  = "cloudera/cdp"
       version = "0.1.3-pre"
     }
 


### PR DESCRIPTION
Use the same provider release, but pull it from the cloudera namespace (cloudera/cdp) instead of cloudera-labs/cdp